### PR TITLE
Over-verbose storecode log fix

### DIFF
--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -26,7 +26,8 @@ func ABCIQuery(
 	if err != nil {
 		return nil, err
 	}
-	env.Logger.Info("ABCIQuery", "path", path, "data", data, "result", resQuery)
+	env.Logger.Info("ABCIQuery", "path", path, "result", resQuery)
+	env.Logger.Debug("ABCIQuery", "data", data)
 	return &ctypes.ResultABCIQuery{Response: *resQuery}, nil
 }
 

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -26,8 +26,8 @@ func ABCIQuery(
 	if err != nil {
 		return nil, err
 	}
-	env.Logger.Info("ABCIQuery", "path", path, "result", resQuery)
-	env.Logger.Debug("ABCIQuery", "data", data)
+	env.Logger.Info("ABCIQuery", "path", path, "dataLength", len(data), "resultLength", len(result))
+	env.Logger.Debug("ABCIQuery", "path", path, "result", resQuery, "data", data)
 	return &ctypes.ResultABCIQuery{Response: *resQuery}, nil
 }
 

--- a/rpc/core/abci.go
+++ b/rpc/core/abci.go
@@ -26,7 +26,7 @@ func ABCIQuery(
 	if err != nil {
 		return nil, err
 	}
-	env.Logger.Info("ABCIQuery", "path", path, "dataLength", len(data), "resultLength", len(result))
+	env.Logger.Info("ABCIQuery", "path", path, "dataLength", len(data.Bytes()), "resultLength", len(resQuery.String()))
 	env.Logger.Debug("ABCIQuery", "path", path, "result", resQuery, "data", data)
 	return &ctypes.ResultABCIQuery{Response: *resQuery}, nil
 }


### PR DESCRIPTION
Changed the log level of the ABCIQuery data and result from 'Info' to 'Debug'
Added Info log with length of data and result instead

